### PR TITLE
bug fixes

### DIFF
--- a/src/core/game_functions.rs
+++ b/src/core/game_functions.rs
@@ -1863,7 +1863,7 @@ fn mega_out(mut state: GameState) -> GameState {
             state.runner1 = None;
             state.outs = increment_out(state.outs, 2);
         }
-        _ => state.outs = increment_out(state.outs, 2),
+        _ => state.outs = increment_out(state.outs, 1),
     }
 
     state


### PR DESCRIPTION
- walks no longer advance all runners, only forced advances (https://github.com/hobosock/Deadball-Game/issues/62)
- mega_out() no longer causes 2 outs when no runners are on base (https://github.com/hobosock/Deadball-Game/issues/61)